### PR TITLE
Have color picker bind to $("html") for mousemove/up

### DIFF
--- a/lib/components/color-picker/color-picker.js
+++ b/lib/components/color-picker/color-picker.js
@@ -1,4 +1,3 @@
-
 /**
  * Expose `ColorPicker`.
  */
@@ -103,6 +102,7 @@ ColorPicker.prototype.height = function(n){
 ColorPicker.prototype.spectrumEvents = function(){
   var self = this
     , canvas = $(this.spectrum)
+    , application = $("html")
     , down;
 
   function update(e) {
@@ -118,11 +118,11 @@ ColorPicker.prototype.spectrumEvents = function(){
     update(e);
   });
 
-  canvas.mousemove(function(e){
+  application.mousemove(function(e){
     if (down) update(e);
   });
 
-  canvas.mouseup(function(){
+  application.mouseup(function(){
     down = false;
   });
 };
@@ -136,6 +136,7 @@ ColorPicker.prototype.spectrumEvents = function(){
 ColorPicker.prototype.mainEvents = function(){
   var self = this
     , canvas = $(this.main)
+    , application = $("html")
     , down;
 
   function update(e) {
@@ -151,11 +152,11 @@ ColorPicker.prototype.mainEvents = function(){
     update(e);
   });
 
-  canvas.mousemove(function(e){
+  application.mousemove(function(e){
     if (down) update(e);
   });
 
-  canvas.mouseup(function(){
+  application.mouseup(function(){
     down = false;
   });
 };


### PR DESCRIPTION
This way a drag initiated inside the canvas still work when you end up
going "outside" the lines of the color picker. Otherwise it can be tedious to
get to the very edge of the color picker.
