### PR TITLE
Added an optional `options` argument to the card component for situations where clicking a card to flip is not desired.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -508,6 +508,14 @@ emitter.emit('event', foo, bar, baz);</code></pre>
     })
             </code>
           </pre>
+	  <p>You can also include an object as a third argument to prevent the card component from flipping when clicked. If this argument is not specified, the default behavior is to flip when clicked.</p>
+
+	  <pre>
+	    <code>
+    var card = ui.card('&lt;p&gt;I will not flip when clicked&lt;/p&gt;', '&lt;p&gt;You must have clicked another element&lt;/p&gt;', {self_flip: false});
+    card.el.appendTo('#card');
+            </code>
+	  </pre>
         </section>
       </section>
 

--- a/lib/components/card/card.js
+++ b/lib/components/card/card.js
@@ -10,12 +10,13 @@ exports.Card = Card;
  *
  * @param {Mixed} front
  * @param {Mixed} back
+ * @param {Object} options 
  * @return {Card}
  * @api public
  */
 
-exports.card = function(front, back){
-  return new Card(front, back);
+exports.card = function(front, back, options){
+  return new Card(front, back, options);
 };
 
 /**
@@ -26,15 +27,17 @@ exports.card = function(front, back){
  *
  * @param {Mixed} front
  * @param {Mixed} back
+ * @param {Object} options 
  * @api public
  */
 
-function Card(front, back) {
+function Card(front, back, options) {
   ui.Emitter.call(this);
   this._front = front || $('<p>front</p>');
   this._back = back  || $('<p>back</p>');
   this.template = html;
-  this.render();
+  this.options = options || {self_flip: true};
+  this.render(this.options);
 };
 
 /**
@@ -110,6 +113,8 @@ Card.prototype.render = function(options){
   el.find('.front').empty().append(this._front.el || $(this._front));
   el.find('.back').empty().append(this._back.el || $(this._back));
   el.click(function(){
-    self.flip();
+    if (options.self_flip === true) {
+      self.flip();
+    }
   });
 };


### PR DESCRIPTION
While using the card component in a project, I realized that there are situations where I don't want clicking the card to run `flip()` on it (for example, when putting a draggable map on top of a card I would constantly be flipping the card). 

I noticed that the `options` argument in `Card.prototype.render` did not appear to be currently utilized, so I added  a third optional argument when creating cards which is eventually passed to this function.

``` javascript
var card = ui.card('<p>Front</p>', '<p>Back</p>', {self_flip: false});
```

If the third argument is not included when a card is defined, the card will default to `self_flip: true`. I thought this was a good way to approach this in order to allow `options` to contain other single card-specific configuration settings should more come up in the future. Let me know your thoughts.
