### PR TITLE
Slight tweak to when `show` and `hide` events are emitted.

### DIFF
--- a/build/ui.js
+++ b/build/ui.js
@@ -270,13 +270,13 @@ Dialog.prototype.overlay = function(){
  */
 
 Dialog.prototype.show = function(){
-  this.emit('show');
   if (this._overlay) {
     this._overlay.show();
     this.el.addClass('modal');
   }
   this.el.appendTo('body');
   this.el.css({ marginLeft: -(this.el.width() / 2) + 'px' });
+  this.emit('show');
   return this;
 };
 
@@ -293,7 +293,6 @@ Dialog.prototype.show = function(){
 
 Dialog.prototype.hide = function(ms){
   var self = this;
-  this.emit('hide');
 
   // duration
   if (ms) {
@@ -327,6 +326,7 @@ Dialog.prototype.hide = function(ms){
  */
 
 Dialog.prototype.remove = function(){
+  this.emit('hide');
   this.el.remove();
   return this;
 };

--- a/lib/components/dialog/dialog.js
+++ b/lib/components/dialog/dialog.js
@@ -164,13 +164,13 @@ Dialog.prototype.overlay = function(){
  */
 
 Dialog.prototype.show = function(){
-  this.emit('show');
   if (this._overlay) {
     this._overlay.show();
     this.el.addClass('modal');
   }
   this.el.appendTo('body');
   this.el.css({ marginLeft: -(this.el.width() / 2) + 'px' });
+  this.emit('show');
   return this;
 };
 
@@ -187,7 +187,6 @@ Dialog.prototype.show = function(){
 
 Dialog.prototype.hide = function(ms){
   var self = this;
-  this.emit('hide');
 
   // duration
   if (ms) {
@@ -221,6 +220,7 @@ Dialog.prototype.hide = function(ms){
  */
 
 Dialog.prototype.remove = function(){
+  this.emit('hide');
   this.el.remove();
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   , "description": "JavaScript + CSS UI components"
   , "keywords": []
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
+  , "contributors": [{
+        "name": "Henrik Joreteg"
+      , "email": "henrik@andyet.net"
+   	}]
   , "dependencies": {}
   , "main": "index"
   , "engines": { "node": "0.4.x" }


### PR DESCRIPTION
Hey, dude.

The `show` event was being emitted immediately when showing dialogs, but if I want to do something with the contents of the dialog such as `.focus()` on an input I can't do that until it's attached to the DOM. So I moved `show` to trigger a bit later. Figured I'd toss it back, if you thought it made sense.

Also, and perhaps this was intentional. But calling `hide` with a delay would trigger the `hide` event before the delay actually expired. This could be argued, but it seems more useful to actually emit that event right before the element is actually removed from the DOM.
