### PR TITLE
Fix IE8 error when a notification with effect closes

### DIFF
--- a/lib/components/notification/notification.js
+++ b/lib/components/notification/notification.js
@@ -217,9 +217,9 @@ Notification.prototype.hide = function(ms){
   // hide / remove
   this.el.addClass('hide');
   if (this._effect) {
-    setTimeout(function(self){
+    setTimeout(function(){
       self.remove();
-    }, 500, this);
+    }, 500);
   } else {
     self.remove();
   }


### PR DESCRIPTION
use closure instead of IE's broken setTimeout argument passing
