### PR TITLE
Fix IE8 error when a Dialog with effect closes

### DIFF
--- a/lib/components/dialog/dialog.js
+++ b/lib/components/dialog/dialog.js
@@ -225,9 +225,9 @@ Dialog.prototype.hide = function(ms){
   // hide / remove
   this.el.addClass('hide');
   if (this._effect) {
-    setTimeout(function(self){
+    setTimeout(function(){
       self.remove();
-    }, 500, this);
+    }, 500);
   } else {
     self.remove();
   }


### PR DESCRIPTION
use trusty closure instead of IE's broken setTimeout argument passing
