### PR TITLE
Return false from ui.Confirmation callback cancels dialog close

### DIFF
--- a/build/ui.js
+++ b/build/ui.js
@@ -330,9 +330,9 @@ Dialog.prototype.hide = function(ms){
   // hide / remove
   this.el.addClass('hide');
   if (this._effect) {
-    setTimeout(function(self){
+    setTimeout(function(){
       self.remove();
-    }, 500, this);
+    }, 500);
   } else {
     self.remove();
   }
@@ -448,7 +448,7 @@ Overlay.prototype.hide = function(){
 exports.Confirmation = Confirmation;
 
 /**
- * Return a new `Confirmation` dialog with the given 
+ * Return a new `Confirmation` dialog with the given
  * `title` and `msg`.
  *
  * @param {String} title or msg
@@ -562,15 +562,16 @@ Confirmation.prototype.render = function(options){
   actions.find('.cancel').click(function(e){
     e.preventDefault();
     self.emit('cancel');
-    self.callback(false);
+    self.callback(false)
     self.hide();
   });
 
   actions.find('.ok').click(function(e){
     e.preventDefault();
     self.emit('ok');
-    self.callback(true);
-    self.hide();
+    if (self.callback(true) !== false) {
+      self.hide();
+    }
   });
 };
 
@@ -1148,9 +1149,9 @@ Notification.prototype.hide = function(ms){
   // hide / remove
   this.el.addClass('hide');
   if (this._effect) {
-    setTimeout(function(self){
+    setTimeout(function(){
       self.remove();
-    }, 500, this);
+    }, 500);
   } else {
     self.remove();
   }
@@ -1297,7 +1298,7 @@ exports.Menu = Menu;
  */
 
 exports.menu = function(){
-  return new Menu();
+  return new Menu;
 };
 
 /**

--- a/build/ui.js
+++ b/build/ui.js
@@ -563,6 +563,14 @@ Confirmation.prototype.render = function(options){
   actions.find('.cancel').click(function(e){
     e.preventDefault();
     self.emit('cancel');
+    if(self.async){
+        self.callback(false, function () {
+            self.hide();
+        });
+    }
+    else {
+        (self.callback(false) !== false && self.hide());
+    }
     self.callback(false)
     self.hide();
   });
@@ -576,7 +584,7 @@ Confirmation.prototype.render = function(options){
       });
     }
     else{
-      self.callback(true) !== false && self.hide();
+      (self.callback(true) !== false && self.hide());
     }
   });
 };

--- a/build/ui.js
+++ b/build/ui.js
@@ -117,7 +117,7 @@ var active;
 exports.Dialog = Dialog;
 
 /**
- * Return a new `Dialog` with the given 
+ * Return a new `Dialog` with the given
  * (optional) `title` and `msg`.
  *
  * @param {String} title or msg
@@ -529,10 +529,11 @@ Confirmation.prototype.ok = function(text){
  * @api public
  */
 
-Confirmation.prototype.show = function(fn){
+Confirmation.prototype.show = function(fn, async){
   ui.Dialog.prototype.show.call(this);
   this.el.find('.ok').focus();
   this.callback = fn || function(){};
+  this.async = async || false;
   return this;
 };
 
@@ -569,8 +570,13 @@ Confirmation.prototype.render = function(options){
   actions.find('.ok').click(function(e){
     e.preventDefault();
     self.emit('ok');
-    if (self.callback(true) !== false) {
-      self.hide();
+    if(self.async){
+      self.callback(true, function(){
+        self.hide();
+      });
+    }
+    else{
+      self.callback(true) !== false && self.hide();
     }
   });
 };

--- a/lib/components/confirmation/confirmation.js
+++ b/lib/components/confirmation/confirmation.js
@@ -129,8 +129,6 @@ Confirmation.prototype.render = function(options){
     else {
         (self.callback(false) !== false && self.hide());
     }
-    self.callback(false)
-    self.hide();
   });
 
   actions.find('.ok').click(function(e){

--- a/lib/components/confirmation/confirmation.js
+++ b/lib/components/confirmation/confirmation.js
@@ -87,10 +87,11 @@ Confirmation.prototype.ok = function(text){
  * @api public
  */
 
-Confirmation.prototype.show = function(fn){
+Confirmation.prototype.show = function(fn, async){
   ui.Dialog.prototype.show.call(this);
   this.el.find('.ok').focus();
   this.callback = fn || function(){};
+  this.async = async || false;
   return this;
 };
 
@@ -127,8 +128,13 @@ Confirmation.prototype.render = function(options){
   actions.find('.ok').click(function(e){
     e.preventDefault();
     self.emit('ok');
-    if (self.callback(true) !== false) {
-      self.hide();
+    if(self.async){
+      self.callback(true, function(){
+        self.hide();
+      });
+    }
+    else{
+      self.callback(true) !== false && self.hide();
     }
   });
 };

--- a/lib/components/confirmation/confirmation.js
+++ b/lib/components/confirmation/confirmation.js
@@ -6,7 +6,7 @@
 exports.Confirmation = Confirmation;
 
 /**
- * Return a new `Confirmation` dialog with the given 
+ * Return a new `Confirmation` dialog with the given
  * `title` and `msg`.
  *
  * @param {String} title or msg
@@ -120,14 +120,15 @@ Confirmation.prototype.render = function(options){
   actions.find('.cancel').click(function(e){
     e.preventDefault();
     self.emit('cancel');
-    self.callback(false);
+    self.callback(false)
     self.hide();
   });
 
   actions.find('.ok').click(function(e){
     e.preventDefault();
     self.emit('ok');
-    self.callback(true);
-    self.hide();
+    if (self.callback(true) !== false) {
+      self.hide();
+    }
   });
 };

--- a/lib/components/confirmation/confirmation.js
+++ b/lib/components/confirmation/confirmation.js
@@ -121,6 +121,14 @@ Confirmation.prototype.render = function(options){
   actions.find('.cancel').click(function(e){
     e.preventDefault();
     self.emit('cancel');
+    if(self.async){
+        self.callback(false, function () {
+            self.hide();
+        });
+    }
+    else {
+        (self.callback(false) !== false && self.hide());
+    }
     self.callback(false)
     self.hide();
   });
@@ -134,7 +142,7 @@ Confirmation.prototype.render = function(options){
       });
     }
     else{
-      self.callback(true) !== false && self.hide();
+      (self.callback(true) !== false && self.hide());
     }
   });
 };

--- a/lib/components/dialog/dialog.js
+++ b/lib/components/dialog/dialog.js
@@ -12,7 +12,7 @@ var active;
 exports.Dialog = Dialog;
 
 /**
- * Return a new `Dialog` with the given 
+ * Return a new `Dialog` with the given
  * (optional) `title` and `msg`.
  *
  * @param {String} title or msg


### PR DESCRIPTION
Of any relevance, I work with JPJoyal. :)  We were discussing how to not close a confirmation dialog (for example, if the input of a form needs to be validated).  The logical presumption was that you could return false from the callabck -- aka, have it react similarly to event callbacks.  But nope.

Maybe an explicit design decision, so obviously feel free to reject this request if you no likey.
