### PR TITLE
Update overlay.js

### DIFF
--- a/lib/components/overlay/overlay.js
+++ b/lib/components/overlay/overlay.js
@@ -27,7 +27,7 @@ function Overlay(options) {
   ui.Emitter.call(this);
   var self = this;
   options = options || {};
-  this.closable = options.closable;
+  this.closable = options.closable || true;
   this.el = $(html);
   this.el.appendTo('body');
   if (this.closable) {


### PR DESCRIPTION
If options are not defined, closable should still be assigned a value.
